### PR TITLE
Update to make plugin work with GoCD 17.1 and above

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ configurations.all {
 }
 
 dependencies {
-    compile 'cd.go.plugin:go-plugin-api:14.4.0'
+    compile 'cd.go.plugin:go-plugin-api:16.12.0'
+    compile 'cd.go.plugin:gocd-package-material-plugin-shim:16.12.0'
 
     compile 'com.google.code.gson:gson:2.3.1'
 
@@ -75,6 +76,8 @@ dependencies {
 
 jar {
     into('lib') {
-        from configurations.runtime
+        from configurations.runtime {
+            exclude 'go-plugin-api*.jar'
+        }
     }
 }

--- a/src/main/java/com/springer/gocd/cloudfoundry/CloudFoundryProvider.java
+++ b/src/main/java/com/springer/gocd/cloudfoundry/CloudFoundryProvider.java
@@ -5,7 +5,6 @@ import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterial
 import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterialPoller;
 import com.thoughtworks.go.plugin.api.material.packagerepository.PackageMaterialProvider;
 
-@Extension
 public class CloudFoundryProvider implements PackageMaterialProvider {
 
     @Override

--- a/src/main/java/com/springer/gocd/cloudfoundry/NewPackageMaterialProvider.java
+++ b/src/main/java/com/springer/gocd/cloudfoundry/NewPackageMaterialProvider.java
@@ -1,0 +1,33 @@
+package com.springer.gocd.cloudfoundry;
+
+import com.thoughtworks.go.plugin.api.GoApplicationAccessor;
+import com.thoughtworks.go.plugin.api.GoPlugin;
+import com.thoughtworks.go.plugin.api.GoPluginIdentifier;
+import com.thoughtworks.go.plugin.api.annotation.Extension;
+import com.thoughtworks.go.plugin.api.exceptions.UnhandledRequestTypeException;
+import com.thoughtworks.go.plugin.api.material.packagerepository.shim.ReplacementProvider;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+
+@Extension
+public class NewPackageMaterialProvider implements GoPlugin {
+    private ReplacementProvider replacementProvider;
+
+    public NewPackageMaterialProvider() {
+        replacementProvider = new ReplacementProvider(new CloudFoundryProvider());
+    }
+
+    @Override
+    public GoPluginApiResponse handle(GoPluginApiRequest goPluginApiRequest) throws UnhandledRequestTypeException {
+        return replacementProvider.handle(goPluginApiRequest);
+    }
+
+    @Override
+    public GoPluginIdentifier pluginIdentifier() {
+        return replacementProvider.pluginIdentifier();
+    }
+
+    @Override
+    public void initializeGoApplicationAccessor(GoApplicationAccessor goApplicationAccessor) {
+    }
+}


### PR DESCRIPTION
Using the [plugin shim](https://github.com/gocd-contrib/gocd-package-material-plugin-shim) to upgrade this plugin, so that it works with 17.1. Without this change, this plugin will stop working from GoCD 17.1 onwards.